### PR TITLE
feat: implement retry strategies ♻️

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module go.strv.io/background
 
 go 1.22.0
 
-require github.com/stretchr/testify v1.8.4
+require (
+	github.com/kamilsk/retry/v5 v5.0.0-rc8
+	github.com/stretchr/testify v1.8.4
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kamilsk/retry/v5 v5.0.0-rc8 h1:7gPn+mf/wYpiBdovfFtE9jJ2O4eFny8Y/p6vrXON8ZI=
+github.com/kamilsk/retry/v5 v5.0.0-rc8/go.mod h1:pY2mWDkk4Ld6B4XFBk4GiPIUSIjIAHuvRZczhbcWKQs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=


### PR DESCRIPTION
Now the task can be set up to retry on failure. By default, we only make a single execution attempt.

The retry mechanism is implemented in https://github.com/kamilsk/retry/v5 . I chose this package over https://github.com/eapache/go-resiliency because `retry` has a much more flexible API, provides a ton of strategies and backoff algorithms and the strategies are nicely defined via an interface, making extensions and customisations very easy.

Unfortunately, the last update to `retry` was in February 2021 so I might yet regret this decision but for the time being I feel like this is the superior choice over `go-resiliency`.

> This partially implements #5. More work is still needed to incorporate all features from that pull request, namely being able to cancel long-running tasks.