### PR TITLE
feat: implement periodic/looping tasks ♻️

### DIFF
--- a/internal.go
+++ b/internal.go
@@ -1,10 +1,64 @@
 package background
 
 import (
+	"context"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/kamilsk/retry/v5/strategy"
 )
+
+// taskmgr is used internally for task tracking and synchronization.
+type taskmgr struct {
+	group sync.WaitGroup
+	count atomic.Int32
+}
+
+// start tells the taskmgr that a new task has started.
+func (m *taskmgr) start() {
+	m.group.Add(1)
+	m.count.Add(1)
+}
+
+// finish tells the taskmgr that a task has finished.
+func (m *taskmgr) finish() {
+	m.group.Done()
+	m.count.Add(-1)
+}
+
+// loopmgr is used internally for loop tracking and synchronization and cancellation of the loops.
+type loopmgr struct {
+	group    sync.WaitGroup
+	count    atomic.Int32
+	ctx      context.Context
+	cancelfn context.CancelFunc
+}
+
+func mkloopmgr() loopmgr {
+	ctx, cancelfn := context.WithCancel(context.Background())
+	return loopmgr{
+		ctx:      ctx,
+		cancelfn: cancelfn,
+	}
+}
+
+// start tells the loopmgr that a new loop has started.
+func (m *loopmgr) start() {
+	m.group.Add(1)
+	m.count.Add(1)
+}
+
+// cancel tells the loopmgr that a loop has finished.
+func (m *loopmgr) finish() {
+	m.group.Done()
+	m.count.Add(-1)
+}
+
+func (m *loopmgr) cancel() {
+	m.cancelfn()
+	m.group.Wait()
+}
 
 // mktimeout returns a channel that will receive the current time after the specified duration. If the duration is 0,
 // the channel will never receive any message.


### PR DESCRIPTION
> Closes #5 

This is an alternative implementation of what @CermakM proposed in #5 that retains the previous functionality (one-off task executions, hooks/observer methods, etc.) and adds a periodic/looping tasks on top of that.

### Some implementation notes:

- the tasks are restarted immediately when the previous function's iteration returns.
- if the task returns an error, retry policies are applied just like for one-off tasks. Retries happen within the same loop iteration.
- if the retries are not successful, the observer's `OnTaskFailed()` method is called and a new loop starts again.
- the `OnTaskStalled()` and `OnTaskSucceeded()`  methods are ignored for loop tasks.