### PR TITLE
feat: cleanup & tweaks, vol.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 ---
-name: Tests
+name: Continuous Integration
 
 on:
   push:
@@ -8,7 +8,20 @@ on:
   pull_request:
 
 jobs:
-  tests:
+  lint:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go version
+      - run: make lint
+
+  test:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:

--- a/background.go
+++ b/background.go
@@ -99,11 +99,12 @@ func (m *Manager) Cancel() {
 // Close is a convenience method that calls Wait() and Cancel() in parallel. It blocks until all tasks have finished.
 func (m *Manager) Close() {
 	var wg sync.WaitGroup
-	wg.Add(2)
+	wg.Add(1)
 	go func() {
 		m.Wait()
 		wg.Done()
 	}()
+	wg.Add(1)
 	go func() {
 		m.Cancel()
 		wg.Done()

--- a/background.go
+++ b/background.go
@@ -2,27 +2,10 @@ package background
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/kamilsk/retry/v5"
 	"github.com/kamilsk/retry/v5/strategy"
-)
-
-// TaskType determines how the task will be executed by the manager.
-type TaskType int
-
-const (
-	// TaskTypeOneOff is the default task type. It will be executed only once.
-	TaskTypeOneOff TaskType = iota
-	// TaskTypeLoop will be executed in an infinite loop until the manager's Cancel() method is called. The task will
-	// restart immediately after the previous iteration returns.
-	TaskTypeLoop
-)
-
-var (
-	// ErrUnknownTaskType is returned when the task type is not a valid value of TaskType.
-	ErrUnknownTaskType = errors.New("unknown task type")
 )
 
 // Manager keeps track of scheduled goroutines and provides mechanisms to wait for them to finish or cancel their
@@ -49,31 +32,9 @@ type Options struct {
 	Retry Retry
 }
 
-// Task describes how a unit of work (a function) should be executed.
-type Task struct {
-	// Fn is the function to be executed in a goroutine.
-	Fn Fn
-	// Type is the type of the task. It determines how the task will be executed by the manager. Default is TaskTypeOneOff.
-	Type TaskType
-	// Meta is whatever custom information you wish to associate with the task. This will be passed to the observer's
-	// functions.
-	Meta Metadata
-	// Retry defines how the task should be retried in case of failure (if at all). This overrides the default retry
-	// strategies you might have configured in the Manager. Several strategies are provided by
-	// github.com/kamilsk/retry/v5/strategy package.
-	Retry Retry
-}
-
 // Retry defines the functions that control the retry behavior of a task. Several strategies are provided by
 // github.com/kamilsk/retry/v5/strategy package.
 type Retry []strategy.Strategy
-
-// Fn is the function to be executed in a goroutine.
-type Fn func(ctx context.Context) error
-
-// Metadata is whatever custom information you wish to associate with a task. You can access this data in the observer's
-// methods to help you identify the task or get more context about it.
-type Metadata map[string]string
 
 // NewManager creates a new instance of Manager with default options and no observer.
 func NewManager() *Manager {

--- a/background.go
+++ b/background.go
@@ -2,6 +2,7 @@ package background
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/kamilsk/retry/v5"
@@ -93,6 +94,21 @@ func (m *Manager) Wait() {
 // cancelled. Adding a new loop task after calling Cancel() will cause the task to be ignored and not run.
 func (m *Manager) Cancel() {
 	m.loopmgr.cancel()
+}
+
+// Close is a convenience method that calls Wait() and Cancel() in parallel. It blocks until all tasks have finished.
+func (m *Manager) Close() {
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		m.Wait()
+		wg.Done()
+	}()
+	go func() {
+		m.Cancel()
+		wg.Done()
+	}()
+	wg.Wait()
 }
 
 // CountOf returns the number of tasks of the specified type that are currently running. When the TaskType is invalid it

--- a/background_test.go
+++ b/background_test.go
@@ -83,8 +83,8 @@ func Test_OnTaskAdded(t *testing.T) {
 	executed := false
 	var wg sync.WaitGroup
 	m := background.NewManagerWithOptions(background.Options{
-		Observer: background.Observer{
-			OnTaskAdded: func(ctx context.Context, task background.Task) {
+		Observer: background.DefaultObserver{
+			HandleOnTaskAdded: func(ctx context.Context, task background.Task) {
 				assert.Equal(t, metadata, task.Meta)
 				executed = true
 				wg.Done()
@@ -110,8 +110,8 @@ func Test_OnTaskSucceeded(t *testing.T) {
 	executed := false
 	var wg sync.WaitGroup
 	m := background.NewManagerWithOptions(background.Options{
-		Observer: background.Observer{
-			OnTaskSucceeded: func(ctx context.Context, task background.Task) {
+		Observer: background.DefaultObserver{
+			HandleOnTaskSucceeded: func(ctx context.Context, task background.Task) {
 				assert.Equal(t, metadata, task.Meta)
 				executed = true
 				wg.Done()
@@ -137,8 +137,8 @@ func Test_OnTaskFailed(t *testing.T) {
 	executed := false
 	var wg sync.WaitGroup
 	m := background.NewManagerWithOptions(background.Options{
-		Observer: background.Observer{
-			OnTaskFailed: func(ctx context.Context, task background.Task, err error) {
+		Observer: background.DefaultObserver{
+			HandleOnTaskFailed: func(ctx context.Context, task background.Task, err error) {
 				assert.Equal(t, metadata, task.Meta)
 				assert.Error(t, err)
 				executed = true
@@ -182,8 +182,8 @@ func Test_OnTaskStalled(t *testing.T) {
 
 			m := background.NewManagerWithOptions(background.Options{
 				StalledThreshold: time.Millisecond * 5,
-				Observer: background.Observer{
-					OnTaskStalled: func(ctx context.Context, task background.Task) {
+				Observer: background.DefaultObserver{
+					HandleOnTaskStalled: func(ctx context.Context, task background.Task) {
 						assert.Equal(t, metadata, task.Meta)
 						executed = true
 						wg.Done()
@@ -214,8 +214,8 @@ func Test_StalledTaskStillCallsOnTaskSucceeded(t *testing.T) {
 	var wg sync.WaitGroup
 	m := background.NewManagerWithOptions(background.Options{
 		StalledThreshold: time.Millisecond,
-		Observer: background.Observer{
-			OnTaskSucceeded: func(ctx context.Context, task background.Task) {
+		Observer: background.DefaultObserver{
+			HandleOnTaskSucceeded: func(ctx context.Context, task background.Task) {
 				executed = true
 				wg.Done()
 			},
@@ -293,8 +293,8 @@ func Test_RunTaskTypeLoop_RetryStrategies(t *testing.T) {
 	count := 0
 
 	m := background.NewManagerWithOptions(background.Options{
-		Observer: background.Observer{
-			OnTaskFailed: func(ctx context.Context, task background.Task, err error) {
+		Observer: background.DefaultObserver{
+			HandleOnTaskFailed: func(ctx context.Context, task background.Task, err error) {
 				done <- err
 			},
 		},

--- a/task.go
+++ b/task.go
@@ -1,0 +1,44 @@
+package background
+
+import (
+	"context"
+	"errors"
+)
+
+// TaskType determines how the task will be executed by the manager.
+type TaskType int
+
+const (
+	// TaskTypeOneOff is the default task type. It will be executed only once.
+	TaskTypeOneOff TaskType = iota
+	// TaskTypeLoop will be executed in an infinite loop until the manager's Cancel() method is called. The task will
+	// restart immediately after the previous iteration returns.
+	TaskTypeLoop
+)
+
+var (
+	// ErrUnknownTaskType is returned when the task type is not a valid value of TaskType.
+	ErrUnknownTaskType = errors.New("unknown task type")
+)
+
+// Task describes how a unit of work (a function) should be executed.
+type Task struct {
+	// Fn is the function to be executed in a goroutine.
+	Fn Fn
+	// Type is the type of the task. It determines how the task will be executed by the manager. Default is TaskTypeOneOff.
+	Type TaskType
+	// Meta is whatever custom information you wish to associate with the task. This will be passed to the observer's
+	// functions.
+	Meta Metadata
+	// Retry defines how the task should be retried in case of failure (if at all). This overrides the default retry
+	// strategies you might have configured in the Manager. Several strategies are provided by
+	// github.com/kamilsk/retry/v5/strategy package.
+	Retry Retry
+}
+
+// Fn is the function to be executed in a goroutine.
+type Fn func(ctx context.Context) error
+
+// Metadata is whatever custom information you wish to associate with a task. You can access this data in the observer's
+// methods to help you identify the task or get more context about it.
+type Metadata map[string]string


### PR DESCRIPTION
This is the final round of "random" tweaks and improvements before I move on to rewriting the README.

- refactored the `Observer` struct into an interface and provided the `DefaultObserver` as an implementation of it
- moved `Task` struct and related functionality into a separate file
- implemented `Manager.Close()` that is a helper function which calls both `.Wait()` and `.Cancel()` in parallel. Useful to completely shut this thing down all at once.
- minor tweaks to the CI definition, plus added a lint step to the pipeline. 🎨 