### PR TITLE
build: improve developer experience ❤️

### DIFF
--- a/.github/matchers/golangci-lint.json
+++ b/.github/matchers/golangci-lint.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "golangci-lint",
+      "pattern": [
+        {
+          "regexp": "^(.+\\.go):(\\d+):(\\d+): \\w+: (.+) \\((\\w+)\\)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/matchers/testify.json
+++ b/.github/matchers/testify.json
@@ -1,0 +1,27 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "github.com/stretchr/testify/assert",
+      "pattern": [
+        {
+          "regexp": "^\\s+Error Trace:\\s+(.+):(\\d+)$",
+          "file": 1,
+          "line": 2
+        },
+        {
+          "regexp": "^\\s+Error:\\s+(.+)(?=:?)",
+          "message": 1
+        }
+      ]
+    },
+    {
+      "owner": "go",
+      "pattern": [
+        {
+          "regexp": "^(panic: .+)$",
+          "message": 1
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,8 @@ jobs:
         with:
           go-version-file: go.mod
       - run: go version
+      - run: echo "::add-matcher::.github/matchers/golangci-lint.json"
+
       - run: make lint
 
   test:
@@ -32,6 +34,8 @@ jobs:
         with:
           go-version-file: go.mod
       - run: go version
+      - run: echo "::add-matcher::.github/matchers/testify.json"
+
       - run: make test
       - name: Upload coverage reports to Codecov
         if: success()

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "github.vscode-github-actions",
+    "github.vscode-pull-request-github",
+    "golang.go"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "task.allowAutomaticTasks": "off",
+  "window.title": "go.strv.io/background${separator}${activeEditorShort}",
+  "go.lintTool": "golangci-lint",
+  "go.testTimeout": "5s",
+  "go.useLanguageServer": true,
+  "gopls": {
+    "ui.semanticTokens": true,
+  },
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,101 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "make: test",
+      "detail": "Run the test suite",
+      "type": "process",
+      "command": "make",
+      "args": [
+        "test"
+      ],
+      "problemMatcher": {
+        "owner": "github.com/stretchr/testify/assert",
+        "applyTo": "allDocuments",
+        "fileLocation": [
+          "absolute"
+        ],
+        "pattern": [
+          {
+            "regexp": "^\\s+Error Trace:\\s+(.+):(\\d+)$",
+            "file": 1,
+            "line": 2
+          },
+          // This is extremely rudimentary because VS Code does not support matching the message across multiple lines
+          // so this only shows the error but does not show the expected and actual values in the UI 🤦‍♂️
+          {
+            "regexp": "^\\s+Error:\\s+(.+)(?=:?)",
+            "message": 1
+          }
+        ]
+      },
+      "isTestCommand": true,
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "presentation": {
+        "clear": true
+      },
+      "icon": {
+        "id": "beaker",
+        "color": "terminal.ansiGreen"
+      }
+    },
+    {
+      "label": "make: lint",
+      "detail": "Run the linter using Docker (golangci-lint)",
+      "type": "process",
+      "command": "make",
+      "args": [
+        "lint"
+      ],
+      "problemMatcher": {
+        "owner": "golangci-lint",
+        "applyTo": "allDocuments",
+        "fileLocation": [
+          "relative",
+          "${workspaceFolder}"
+        ],
+        "pattern": {
+          "regexp": "^(.+\\.go):(\\d+):(\\d+): \\w+: (.+) \\((\\w+)\\)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        },
+      },
+      "group": {
+        "kind": "test",
+        "isDefault": false
+      },
+      "presentation": {
+        "clear": true,
+      },
+      "icon": {
+        "id": "eye",
+        "color": "terminal.ansiYellow"
+      }
+    },
+    {
+      "label": "make: clean",
+      "detail": "Remove compiled and generated files or caches",
+      "type": "process",
+      "command": "make",
+      "args": [
+        "clean"
+      ],
+      "problemMatcher": [],
+      "presentation": {
+        "showReuseMessage": false,
+        "clear": true,
+        "close": true
+      },
+      "icon": {
+        "id": "trash",
+        "color": "terminal.ansiRed"
+      }
+    }
+  ],
+}

--- a/makefile
+++ b/makefile
@@ -1,12 +1,13 @@
 all: lint test
 
 lint: force
-	./tools/golangci-lint run -v
+	./tools/golangci-lint run --verbose
 
 test: force
 	go test -v -timeout 5s -covermode=atomic -coverprofile=coverage.txt ./...
 
 clean:
 	rm -rf .cache
+	rm coverage.txt
 
 .PHONY: force

--- a/tools/golangci-lint
+++ b/tools/golangci-lint
@@ -11,4 +11,4 @@ exec docker run -t \
   --volume "$(pwd):/app" \
   --volume "$(pwd)/.cache/golangci-lint:/root/.cache" \
   --workdir /app \
-  "$image" golangci-lint "$@"
+  "$image" golangci-lint --color never "$@" # Force no colour output to allow GH Actions problem matchers to work


### PR DESCRIPTION
- provides a bunch of goodies for VS Code users, like mapping the test command to the default test task in VS Code (so you can run your test suite with a keyboard shortcut)
- adds a list of recommended extensions, in case you are new to either Go or VS Code
- provides some basic VS Code configuration to make working with Go nicer
- provides problem matchers for both VS Code and Github Actions. In VS Code, test failures and lint issues are automatically listed also in the Problems panel. In Actions, the same issues are now listed in the Action run's Summary as Annotations.